### PR TITLE
Refactor JS result to include preset groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,19 @@ Use [sharp] to automatically generate image assets with [webpack].
 
 ## Usage
 
+```sh
+npm install --save sharp-loader sharp
+```
+
+
+
 Setup presets in your loader:
 
 ```javascript
 {
 	module: {
 		loaders: [{
-			test: /\.(gif|jpe?g|png|tiff)(\?.*)?$/,
+			test: /\.(gif|jpe?g|png|svg|tiff)(\?.*)?$/,
 			loader: 'sharp-loader',
 			query: {
 				name: '[name].[hash:8].[ext]',
@@ -39,14 +45,41 @@ Setup presets in your loader:
 
 ```
 
-Use those presets in your code:
+Use without presets generating a single image:
+
+```javascript
+const images = require('./aQHsOG6.jpg?width=500');
+console.log(images.format); // 'image/jpeg'
+console.log(images.url) // url to image
+```
+
+
+Use single preset generating multiple images:
+
+```javascript
+const images = require('./aQHsOG6.jpg?preset=thumbnail');
+console.log(images.length); // 1
+console.log(images[0].url) // url to image
+```
+
+Use multiple presets generating multiple images:
 
 ```javascript
 const images = require('./aQHsOG6.jpg?presets[]=thumbnail&presets[]=prefetch');
-console.log(images.length); // 10
-console.log(images[0].format) // webp
-console.log(images[0].url) // url to image
+console.log(Object.keys(images).length); // 2
+console.log(images.prefetch.format) // image/jpeg
+console.log(images.thumbnail.length) // 2
 ```
+
+Altering preset behavior:
+
+```javascript
+const images = require('./aQHsOG6.jpg?{"presets": { "thumbnail": { "size": 400 } }}');
+console.log(Object.keys(images).length); // 1
+console.log(images.prefetch.format) // image/jpeg
+console.log(images.thumbnail.length) // 2
+```
+
 
 [sharp]: https://github.com/lovell/sharp
 [webpack]: https://github.com/webpack/webpack

--- a/example/index.js
+++ b/example/index.js
@@ -1,2 +1,6 @@
 
-console.log(require('./aQHsOG6.jpg?presets[]=thumbnail&presets[]=prefetch'));
+var a = require('./aQHsOG6.jpg?presets[]=thumbnail&presets[]=prefetch');
+var b = require('./aQHsOG6.jpg?presets[]=thumbnail&presets[]=prefetch');
+var c = require('./aQHsOG6.jpg?{"presets":{"thumbnail":{"size": 400}}}');
+
+console.log(a, b);

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
 	module: {
 		loaders: [{
 			test: /\.(gif|jpe?g|png|tiff)(\?.*)?$/,
-			loader: 'sharp-loader',
+			loader: path.join(__dirname, '..'),
 			query: {
 				name: '[name].[hash:8].[ext]',
 				presets: {

--- a/lib/sharp.js
+++ b/lib/sharp.js
@@ -3,6 +3,7 @@ var _ = require('lodash');
 var sharp = require('sharp');
 var loaderUtils = require('loader-utils');
 var multiplex = require('option-multiplexer');
+var mime = require('mime');
 var Promise = require('bluebird');
 
 /**
@@ -44,27 +45,6 @@ function extension(type) {
 		'jpeg': '.jpg',
 		'png': '.png'
 	}[type];
-}
-
-/**
- * Some presets may want to alter their behavior based on image metadata; this
- * function invokes any preset value which is a function and assigns the result
- * to a new generated preset.
- * @param {Object} preset Preset.
- * @param {Object} metadata Image metadata.
- * @returns {Object} New preset.
- */
-function localize(metadata, preset, defaults) {
-	var props = [ 'format', 'name' ];
-	var initial = _.assign(
-		{ },
-		_.pick(defaults, props),
-		_.pick(metadata, props),
-		preset
-	);
-	return _.mapValues(initial, function(value) {
-		return _.isFunction(value) ? value(metadata) : value;
-	});
 }
 
 /**
@@ -124,15 +104,7 @@ function getPresets(localQuery, globalQuery) {
 	} else if (!localQuery.presets) {
 		throw new Error('No presets selected.');
 	}
-
-	return localQuery.presets.map(function(id) {
-		var preset = globalQuery.presets[id];
-		if (!preset) {
-			throw new Error('No such preset: ' + id);
-		}
-		preset.preset = id;
-		return preset;
-	});
+	return _.pick(globalQuery.presets, localQuery.presets);
 }
 
 
@@ -140,9 +112,10 @@ function getPresets(localQuery, globalQuery) {
 function emit(context) {
 	var publicPath = context.options.output.publicPath || '/';
 	var query = loaderUtils.parseQuery(context.query);
+	var template = query.name;
 
 	function name(image, info, options) {
-		var template = options.name;
+
 		return loaderUtils.interpolateName({
 			resourcePath: context.resourcePath
 				.replace(/\.[^.]+$/, extension(info.format))
@@ -154,21 +127,22 @@ function emit(context) {
 
 	function data(image, info, options) {
 		var n = name(image, info, options);
+		var format = mime.lookup(n);
 		if (options.inline) {
-			return {
+			return _.assign({
 				name: n,
 				url: [
-					'data:image/',
-					info.format,
+					'data:',
+					format,
 					';base64,',
 					image.toString('base64')
 				].join('')
-			}
+			}, info, { format: format });
 		} else {
 			context.emitFile(n, image);
-			return {
+			return _.assign({
 				url: publicPath + n
-			};
+			}, info, { format: format });
 		}
 	}
 
@@ -182,50 +156,75 @@ function emit(context) {
 				if (err) {
 					reject(err);
 				} else {
-					resolve(_.assign({
-						preset: options.preset
-					}, data(buffer, info, options), info))
+					resolve(data(buffer, info, options));
 				}
 			})
 		});
 	}
 }
 
+function handle(image, preset, name, presets, emit) {
+	function wahoo(options) {
+		return Promise.props({
+			options: options,
+			image: transform(image, normalize(options))
+		}).then(emit);
+	}
+	var values = multiplex(_.assign({ }, presets[name], preset));
+	if (values.length > 1) {
+		return Promise.map(values, wahoo);
+	} else if (values.length === 1) {
+		return wahoo(values[0]);
+	}
+	throw new TypeError();
+}
+
+
+
+function lolol(image, presets, globals, emit) {
+	if (_.isArray(presets)) {
+		return Promise.props(_.object(presets, presets.map(function (name) {
+			return handle(image, null, name, globals, emit);
+		})));
+	} else if (_.isObject(presets)) {
+		return Promise.props(_.mapValues(presets, function(preset, name) {
+			return handle(image, preset, name, globals, emit);
+		}))
+	} else if (isString(presets)) {
+		return handle(image, null, presets, globals, emit);
+	}
+	throw new TypeError();
+}
+
 module.exports = function(input) {
+	// This means that, for a given query string, the loader will only be
+	// run once. No point in barfing out the same image over and over.
 	this.cacheable();
 
 	var localQuery = loaderUtils.parseQuery(this.resourceQuery);
 	var globalQuery = loaderUtils.parseQuery(this.query);
-
-	var single = false;
-	var presets = localQuery.presets ?
-		getPresets(localQuery, globalQuery) : [ localQuery ];
-
+	var assets;
 	var image = sharp(input);
 	var meta = image.metadata();
 	var callback = this.async();
+	var e = emit(this);
 
-	var assets = Promise.map(presets, Promise.resolve)
-		.map(function(preset) {
-			return meta.then(function(meta) {
-				return localize(meta, preset, globalQuery);
-			});
-		})
-		.reduce(function(presets, preset) {
-			return presets.concat(multiplex(preset));
-		}, [])
-		.map(function(options) {
-			return Promise.props({
-				options: options,
-				image: transform(image, normalize(options))
-			});
-		})
-		.map(emit(this));
+	// We have three possible choices:
+	// - set of presets in `presets`
+	// - single preset in `preset`
+	// - single value
+	if (localQuery.presets) {
+		assets = lolol(image, localQuery.presets, globalQuery.presets, e);
+	} else if (localQuery.preset) {
+		assets = lolol(image, localQuery.preset, globalQuery.presets, e);
+	} else {
+		assets = lolol(image, localQuery, globalQuery.presets, e);
+	}
 
-	Promise.all(assets).then(function(assets) {
+	assets.then(function(assets) {
 		return 'module.exports = ' + JSON.stringify(assets) + ';';
 	}).nodeify(callback);
 };
 
-// Force buffers.
+// Force buffers since sharp doesn't want strings.
 module.exports.raw = true;

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
-	"name": "sharp-loader",
-	"version": "0.1.2",
-	"main": "lib/sharp.js",
-	"dependencies": {
-		"loader-utils": "^0.2.11",
-		"bluebird": "^2.10.0",
-		"lodash": "^3.10.1",
-		"option-multiplexer": "^0.1.0"
-	},
-	"peerDependencies": {
-		"sharp": "^0.11.0"
-	}
+  "name": "sharp-loader",
+  "version": "0.1.2",
+  "main": "lib/sharp.js",
+  "dependencies": {
+    "bluebird": "^2.10.0",
+    "loader-utils": "^0.2.11",
+    "lodash": "^3.10.1",
+    "mime": "^1.3.4",
+    "option-multiplexer": "^0.1.0"
+  },
+  "peerDependencies": {
+    "sharp": "^0.11.4"
+  }
 }


### PR DESCRIPTION
Now when using multiple presets the results are grouped by preset.

e.g.

```javascript
{
  "presetA": [ ... ],
  "presetB": { ... }
}
```

Code is still far from perfect, but this should help people access the data they intend to more quickly.