### PR TITLE
Update `sharp` dependency version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "option-multiplexer": "^0.1.0"
   },
   "peerDependencies": {
-    "sharp": "^0.11.4"
+    "sharp": ">=0.12.0"
   }
 }


### PR DESCRIPTION
Version 0.12 includes significant fixes for SVGs, among other things.