### PR TITLE
Update dependencies, fix bugs and make params overridable. 

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,7 +1,9 @@
 
 var a = require('./img/ew3W8.jpg?presets[]=thumbnail&presets[]=prefetch');
 var b = require('./img/ew3W8.jpg?presets[]=thumbnail&presets[]=prefetch');
-var c = require('./img/ew3W8.jpg?{"presets":{"thumbnail":{"size": 400}}}');
+var c = require('./img/ew3W8.jpg?{"presets":{"thumbnail":{"width": 400}}}');
 var d = require('./img/visa.svg?height=100&format=png');
+var e = require('./img/ew3W8.jpg?preset=thumbnail');
+var f = require('./img/ew3W8.jpg?preset=thumbnail&width=60');
 
-console.log(a, b, c, d);
+console.log(a, b, c, d, e, f);

--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,8 @@
 {
   "name": "sharp-loader-example",
   "dependencies": {
-    "webpack": "^1.12.1",
-    "sharp-loader": "^0.1.0"
+    "sharp": "^0.15.1",
+    "sharp-loader": "../",
+    "webpack": "^1.12.1"
   }
 }

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -20,8 +20,9 @@ module.exports = {
           thumbnail: {
             format: [ 'webp', 'png', 'jpeg' ],
             density: [ 1, 2, 3 ],
-            size: 200,
-            quality: 60
+            width: 200,
+            height: 200,
+            quality: 60,
           },
           prefetch: {
             format: 'jpeg',
@@ -29,7 +30,8 @@ module.exports = {
             blur: 100,
             quality: 30,
             inline: true,
-            size: 50
+            width: 50,
+            height: 50,
           }
         }
       }

--- a/lib/sharp.js
+++ b/lib/sharp.js
@@ -63,17 +63,13 @@ function normalize(options) {
   }
 
   // Sizing
-  if (options.size) {
-    var size = options.size;
-    size = Array.isArray(size) ? size : [ size, size ];
-    result.resize = size;
-  } else if (options.width || options.height) {
+  if (options.width || options.height) {
     result.resize = [ options.width, options.height ];
   }
 
   if (result.resize) {
     result.resize = result.resize.map(function(value) {
-      return Number(value);
+      return value ? Number(value) : null;
     });
   }
 
@@ -121,7 +117,7 @@ function emit(context) {
   var query = loaderUtils.parseQuery(context.query);
   var template = query.name;
 
-  function name(image, info, options) {
+  function name(image, info, options, preset) {
 
     return loaderUtils.interpolateName({
       resourcePath: context.resourcePath
@@ -132,9 +128,13 @@ function emit(context) {
     });
   }
 
-  function data(image, info, options) {
-    var n = name(image, info, options);
+  function data(image, info, options, preset) {
+    var n = name(image, info, options, preset);
     var format = mime.lookup(n);
+    var extra = {format: format};
+    if (preset) {
+      extra.preset = preset;
+    }
     if (options.inline) {
       return _.assign({
         name: n,
@@ -144,17 +144,17 @@ function emit(context) {
           ';base64,',
           image.toString('base64')
         ].join('')
-      }, info, { format: format });
+      }, options, info, extra);
     } else {
       context.emitFile(n, image);
       return _.assign({
         url: publicPath + n
-      }, info, { format: format });
+      }, options, info, extra);
     }
   }
 
   return function(result) {
-    var image = result.image, options = result.options;
+    var image = result.image, options = result.options, preset = result.preset;
 
     // We have to use the callback form in order to get access to the info
     // object unfortunately.
@@ -163,7 +163,7 @@ function emit(context) {
         if (err) {
           reject(err);
         } else {
-          resolve(data(buffer, info, options));
+          resolve(data(buffer, info, options, preset));
         }
       })
     });
@@ -173,32 +173,29 @@ function emit(context) {
 function handle(image, preset, name, presets, emit) {
   function wahoo(options) {
     return Promise.props({
+      preset: name,
       options: options,
       image: transform(image, normalize(options))
     }).then(emit);
   }
-  var values = multiplex(_.assign({ }, presets[name], preset));
-  if (values.length > 1) {
-    return Promise.map(values, wahoo);
-  } else if (values.length === 1) {
-    return wahoo(values[0]);
+  if (name && !presets[name]) {
+    return [Promise.reject('No such preset: ' + preset)];
   }
-  throw new TypeError();
+  var values = multiplex(_.assign({ }, presets[name] || {}, preset));
+  return _.map(values, wahoo);
 }
 
-
-
-function lolol(image, presets, globals, emit) {
+function lolol(image, extra, presets, globals, emit) {
   if (_.isArray(presets)) {
-    return Promise.props(_.object(presets, presets.map(function (name) {
-      return handle(image, null, name, globals, emit);
-    })));
+    return Promise.all(_.flatMap(presets, function (name) {
+      return handle(image, extra, name, globals, emit);
+    }));
   } else if (_.isObject(presets)) {
-    return Promise.props(_.mapValues(presets, function(preset, name) {
-      return handle(image, preset, name, globals, emit);
-    }))
-  } else if (isString(presets)) {
-    return handle(image, null, presets, globals, emit);
+    return Promise.all(_.flatMap(_.toPairs(presets), function([name, preset]) {
+      return handle(image, _.assign({}, preset, extra), name, globals, emit);
+    }));
+  } else if (_.isString(presets)) {
+    return Promise.all(handle(image, extra, presets, globals, emit));
   }
   throw new TypeError();
 }
@@ -210,6 +207,7 @@ module.exports = function(input) {
 
   var localQuery = loaderUtils.parseQuery(this.resourceQuery);
   var globalQuery = loaderUtils.parseQuery(this.query);
+  var extra = _.omit(localQuery, ['preset', 'presets']);
   var assets;
   var image = sharp(input);
   var meta = image.metadata();
@@ -221,11 +219,11 @@ module.exports = function(input) {
   // - single preset in `preset`
   // - single value
   if (localQuery.presets) {
-    assets = lolol(image, localQuery.presets, globalQuery.presets, e);
+    assets = lolol(image, extra, localQuery.presets, globalQuery.presets, e);
   } else if (localQuery.preset) {
-    assets = lolol(image, localQuery.preset, globalQuery.presets, e);
+    assets = lolol(image, extra, localQuery.preset, globalQuery.presets, e);
   } else {
-    assets = handle(image, localQuery, null, globalQuery.presets, e);
+    assets = Promise.all(handle(image, localQuery, null, globalQuery.presets, e));
   }
 
   assets.then(function(assets) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "bluebird": "^2.10.0",
     "loader-utils": "^0.2.11",
-    "lodash": "^3.10.1",
+    "lodash": "^4.15.0",
     "mime": "^1.3.4",
     "option-multiplexer": "^0.1.0"
   },


### PR DESCRIPTION
 * Update to `lodash^4`.
 * Fix missing `_.` for `_.isString`.
 * Fix `NaN` width/height due to `parseInt` of empty string.
 * Make it so any param in query string overrides preset values, e.g. `?width=xxx&preset=foo`.
 * Always return an array of images.
 * Remove `size` in favor of explicit `width` and `height`.
 * Fail on invalid presets.