### PR TITLE
Add `emit` configuration flag to stop emitted generated images.

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -5,5 +5,6 @@ var c = require('./img/ew3W8.jpg?{"presets":{"thumbnail":{"width": 400}}}');
 var d = require('./img/visa.svg?height=100&format=png');
 var e = require('./img/ew3W8.jpg?preset=thumbnail');
 var f = require('./img/ew3W8.jpg?preset=thumbnail&width=60');
+var g = require('./img/ew3W8.jpg?preset=thumbnail&height=300&emit=false');
 
 console.log(a, b, c, d, e, f);

--- a/src/sharp.js
+++ b/src/sharp.js
@@ -185,6 +185,11 @@ const lolol = (image, extra, presets, globals, emit) => {
   throw new TypeError();
 };
 
+const shouldEmit = (a, b) => {
+  const thing = {...a, ...b};
+  return typeof thing.emit === 'undefined' || thing.emit;
+};
+
 /* eslint import/no-commonjs: 0 */
 /* global module */
 module.exports = function(input) {
@@ -194,11 +199,12 @@ module.exports = function(input) {
 
   const localQuery = loaderUtils.parseQuery(this.resourceQuery);
   const globalQuery = loaderUtils.parseQuery(this.query);
-  const extra = _.omit(localQuery, ['preset', 'presets']);
+  const extra = _.omit(localQuery, ['preset', 'presets', 'emit']);
   let assets;
   const image = sharp(input);
   const callback = this.async();
-  const e = emit(this);
+  const e = shouldEmit(globalQuery, localQuery) ?
+    emit(this) : () => Promise.resolve();
 
   // We have three possible choices:
   // - set of presets in `presets`


### PR DESCRIPTION
For server side rendering you may need the image data but not the generated assets themselves. This flag enables that.